### PR TITLE
activeFilter should have the value its bound to

### DIFF
--- a/src/components/radio-filter/radio-filter.jsx
+++ b/src/components/radio-filter/radio-filter.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
   },
   getInitialState() {
     return {
-      activeFilter: this.props.initialChoice || this.props.options[0].value
+      activeFilter: this.props.value || this.props.initialChoice || this.props.options[0].value
     };
   },
   onChange: function () {


### PR DESCRIPTION
this will prevent having to set both value and initialChoice when binding to the value prop